### PR TITLE
Support leading modifiers in simple expansion

### DIFF
--- a/corpus/broken.txt
+++ b/corpus/broken.txt
@@ -1,0 +1,23 @@
+================================================================================
+Broken: Simple variable expansions with modifiers
+================================================================================
+
+echo $#abc
+
+--------------------------------------------------------------------------------
+
+(program
+; Expected
+; (command
+;   (command_name
+;     (word))
+;   (simple_expansion
+;     (modifier)
+;     (variable_name)))
+  (command
+    (command_name
+      (word))
+    (concatenation
+      (simple_expansion
+        (special_variable_name))
+      (word))))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -56,6 +56,29 @@ echo $0 $# $* $@ $!
     (simple_expansion (special_variable_name))))
 
 =============================
+Simple variable expansions with modifiers
+=============================
+
+echo $^abc
+echo $=abc
+echo $~abc
+echo $+abc
+echo $^~abc
+echo $^~#abc
+echo $^~+abc
+
+---
+
+(program
+  (command (command_name (word)) (simple_expansion (modifier) (variable_name)))
+  (command (command_name (word)) (simple_expansion (modifier) (variable_name)))
+  (command (command_name (word)) (simple_expansion (modifier) (variable_name)))
+  (command (command_name (word)) (simple_expansion (modifier) (variable_name)))
+  (command (command_name (word)) (simple_expansion (modifier) (variable_name)))
+  (command (command_name (word)) (simple_expansion (modifier) (variable_name)))
+  (command (command_name (word)) (simple_expansion (modifier) (variable_name))))
+
+=============================
 Variable expansions
 =============================
 

--- a/grammar.js
+++ b/grammar.js
@@ -50,6 +50,17 @@ module.exports = grammar(bashGrammar, {
     ],
   ],
   rules: {
+    simple_expansion: ($, previous) => choice(
+      previous,
+      seq(
+        '$',
+        alias($._leading_modifiers, $.modifier),
+        choice(
+          $._simple_variable_name,
+          $._special_variable_name,
+        ),
+      ),
+    ),
     expansion: $ => seq(
       '${',
       optional(seq(
@@ -87,7 +98,7 @@ module.exports = grammar(bashGrammar, {
         /[sFW][^}]+/,
       ),
     ),
-    _leading_modifiers: $ => prec.right(choice(
+    _leading_modifiers: $ => prec.right(-1, choice(
       seq(
         repeat1(choice('^', '=', '~')),
         optional(choice('#', '+')),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2034,40 +2034,76 @@
       "value": "\\$'([^']|\\\\')*'"
     },
     "simple_expansion": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "$"
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_simple_variable_name"
+              "type": "STRING",
+              "value": "$"
             },
             {
-              "type": "SYMBOL",
-              "name": "_special_variable_name"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_simple_variable_name"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_special_variable_name"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "!"
+                  },
+                  "named": true,
+                  "value": "special_variable_name"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "#"
+                  },
+                  "named": true,
+                  "value": "special_variable_name"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "$"
             },
             {
               "type": "ALIAS",
               "content": {
-                "type": "STRING",
-                "value": "!"
+                "type": "SYMBOL",
+                "name": "_leading_modifiers"
               },
               "named": true,
-              "value": "special_variable_name"
+              "value": "modifier"
             },
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "STRING",
-                "value": "#"
-              },
-              "named": true,
-              "value": "special_variable_name"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_simple_variable_name"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_special_variable_name"
+                }
+              ]
             }
           ]
         }
@@ -2562,7 +2598,7 @@
     },
     "_leading_modifiers": {
       "type": "PREC_RIGHT",
-      "value": 0,
+      "value": -1,
       "content": {
         "type": "CHOICE",
         "members": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1265,9 +1265,13 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "modifier",
+          "named": true
+        },
         {
           "type": "special_variable_name",
           "named": true


### PR DESCRIPTION
Most leading modifiers are correctly worked, but when using only the `#` modifier parsing is wrong. For fixing this, it might need to drop the `concatenation` node.